### PR TITLE
50: Fix max height of logos and set the width to 100% to ensure Rubys logo shows. Resolves #50

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,7 +40,7 @@ export function Header({
 									<img
 										src={urlForImage(logo.logo_image).toString()}
 										alt={`${logo.name} Logo`}
-										className="max-h-[35px]"
+										className="max-h-[35px] w-full"
 									/>
 								</Link>
 							) : (
@@ -48,7 +48,7 @@ export function Header({
 									key={logo._id}
 									src={urlForImage(logo.logo_image).toString()}
 									alt={`${logo.name} Logo`}
-									className="max-h-[35px]"
+									className="max-h-[35px] w-full"
 								/>
 							);
 						})}


### PR DESCRIPTION
Fix #50

- Content updates made via CMS.
  - About content
  - Joe Delia staff page broken because of apostrophe in name with url parsing. Just removed from page slug in Sanity